### PR TITLE
RFC: Add `@from Module use object as alias` macro.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 [![Build Status][travis-img]][travis-url]
 [![Build status][appveyor-img]][appveyor-url]
 
-Provides two macros: `@import` and `@using` which loads a module and binds it to an alias.
+Provides three macros: `@import` and `@using` which loads a module and binds it to an alias, and
+`@from` which loads an object from a module and binds it to an alias.
 
 ## Usage
 
-The two macros are used in the same way, although the result is different. For instance the
+`@import` and `@using` macros are used in the same way, although the result is different. For instance the
 module `MyLongModuleName` can be imported and bound to `m` with the following line:
 
 ```jl
@@ -34,6 +35,18 @@ MyLongModuleName.foo() # via the original module name
 The syntax for `@using` is the same as for `@import`, the difference being that the module is loaded with
 `using` instead of `import`. This means that exported functions from the module
 can be used directly, and non-exported function can be reached via the alias.
+
+The syntax for `@from` is as follows:
+
+```jl
+@from MyModule use my_long_variable_name as v
+```
+
+In order to alias a macro use `@` before the macro name:
+
+```jl
+@from MyModule use @my_long_macro_name as @m
+```
 
 ## Installation
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.5
+MacroTools

--- a/src/ImportMacros.jl
+++ b/src/ImportMacros.jl
@@ -2,7 +2,10 @@ __precompile__()
 
 module ImportMacros
 
-export @import, @using
+using MacroTools: @capture
+
+export @import, @using, @from
+
 
 """
 ```julia
@@ -34,6 +37,25 @@ const m = MyLongModuleName
 """
 :(@using)
 
+"""
+```julia
+@from Module use object as alias
+@from Module use @object as @alias
+```
+
+Load the module `Module` with `import` and bind `object` to `alias`,
+or `@object` to `@alias` in the case of macros.
+
+Equivalent to:
+
+```julia
+import Module
+const alias = Module.object
+@eval const \$(Symbol("@alias")) = Module.\$(Symbol("@object"))    # macros
+```
+"""
+:(@from)
+
 # generate the macros
 for macroname in ("import", "using")
     @eval begin
@@ -58,6 +80,42 @@ for macroname in ("import", "using")
     end
 end
 
+const FROM_USAGE = "`@from Module use object as alias`"
+const FROM_USAGE_MACRO = "`@from Module use @object as @alias`"
+
+from_error(usage) = throw(ArgumentError("syntax error: expected $usage"))
+
+function _from(condition, usage, _module, object, alias)
+    condition || from_error(usage)
+    isdefined(alias) && throw(ArgumentError("alias `$alias` already defined"))
+
+    names = get_names(_module)
+    import_expr = Expr(:import)
+    for name in names
+        push!(import_expr.args, name)
+    end
+
+    return quote
+        $import_expr
+        const $alias = $_module.$object
+        nothing
+    end |> esc
+end
+
+macro from(_module::Union{Symbol, Expr}, use::Symbol, object::Symbol, as::Symbol, alias::Symbol)
+    condition = use == :use && as == :as
+    _from(condition, FROM_USAGE, _module, object, alias)
+end
+
+macro from(_module::Union{Expr, Symbol}, use::Symbol, object_as_alias::Expr)
+    condition = use == :use && @capture(object_as_alias, @object_ as @alias_)
+    _from(condition, FROM_USAGE_MACRO, _module, object, alias)
+end
+
+macro from(exprs...)
+    from_error("$FROM_USAGE or $FROM_USAGE_MACRO")
+end
+
 # utility function to extract names from expression
 function get_names(x)
     isa(x, Symbol)   && return (x, )
@@ -65,5 +123,6 @@ function get_names(x)
     x.head == :.     && return (get_names(x.args[1])..., get_names(x.args[2])...)
     throw(ArgumentError("invalid module name"))
 end
+
 
 end # module

--- a/test/from_tests.jl
+++ b/test/from_tests.jl
@@ -1,0 +1,38 @@
+# A
+@test (@from A use Foo as f) == nothing
+@from A use foo as f
+@from A use Foo as F
+@from A use @foo as @f
+@from A use @Foo as @F
+@test_throws UndefVarError foo()
+@test_throws UndefVarError Foo()
+@test_throws UndefVarError @eval $(Symbol("@foo"))
+@test_throws UndefVarError @eval $(Symbol("@Foo"))
+@test f()
+@test F()
+@test (@f 1) == 1
+@test @F
+
+# A.B
+@test (@from A.B use Bar as b) == nothing
+@from A.B use bar as b
+@from A.B use Bar as Br
+@from A.B use @bar as @b
+@test_throws UndefVarError bar()
+@test_throws UndefVarError Bar()
+@test_throws UndefVarError @eval $(Symbol("@bar"))
+@test b()
+@test Br()
+@test (@b 1 2) == (1, 2)
+
+# A.B.C
+@test (@from A.B.C use Baz as bz) == nothing
+@from A.B.C use baz as bz
+@from A.B.C use Baz as Bz
+@from A.B.C use @baz as @bz
+@test_throws UndefVarError baz()
+@test_throws UndefVarError Baz()
+@test_throws UndefVarError @eval $(Symbol("@baz"))
+@test bz()
+@test Bz()
+@test (@bz 1 2 3) == (1, 2, 3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,14 +5,18 @@ module A
     export foo
     foo() = true
     Foo() = true
+    macro foo(x) x end
+    macro Foo() true end
     module B
         export bar
         bar() = true
         Bar() = true
+        macro bar(x, y) x, y end
         module C
             export baz
             baz() = true
             Baz() = true
+            macro baz(x, y, z) x, y, z end
         end
     end
 end
@@ -42,6 +46,10 @@ end
     @test abc.baz()
     @test abc.Baz()
 end # testset
+
+@testset "@from" begin
+    include("from_tests.jl")
+end
 
 @testset "@using" begin
     # A


### PR DESCRIPTION
This PR enables using the following syntax:

```julia
@from Module use object as alias
@from Module use @object as @alias
```

To do:

- [x] make tests
- [x] make docstrings
- [x] refactor
- [x] squash commits